### PR TITLE
feat: cleanup redirects and proxy the new site

### DIFF
--- a/redirects-cloud-italia-it/values.yaml
+++ b/redirects-cloud-italia-it/values.yaml
@@ -24,26 +24,20 @@ redirects_cloud_italia_it:
       root /var/www/cloud.italia.it;
       index index.html index.htm;
 
+      # The marketplace section of the site is a different
+      # web application managed by AgID on different server.
+      #
+      # Let's proxy those locations and the main site on GitHub Pages
+      # behind a single hostname (cloud.italia.it).
+
       location / {
-        proxy_pass https://italia.github.io/cloud.italia.it/;
+        proxy_pass https://italia.github.io/cloud.italia.it-site/;
         proxy_set_header Host italia.github.io;
         proxy_set_header X-Forwarded-Proto https;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Scheme $scheme;
         proxy_connect_timeout 10s;
         proxy_read_timeout 20s;
-      }
-
-      location /it/latest {
-        return 301 https://cloud.italia.it;
-      }
-
-      location /projects/cloud-italia-circolari/it/latest/ {
-        return 301 https://cloud-italia.readthedocs.io$request_uri;
-      }
-
-      location /projects/cloud-italia-docs/it/latest/ {
-        return 301 https://docs.italia.it/italia/piano-triennale-ict/cloud-docs;
       }
 
       location ^~ /.well-known {
@@ -55,40 +49,7 @@ redirects_cloud_italia_it:
         deny all;
       }
 
-      location /test-nuovo-marketplace/ { 
-        proxy_pass https://marketplace-test.ecaasagid.cs1.cloudspc.it/;
-        proxy_set_header X-Forwarded-Proto https;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Scheme $scheme;
-        proxy_connect_timeout 10s;
-        proxy_read_timeout 20s;
-        proxy_ssl_server_name on;
-        proxy_ssl_name marketplace.ecaasagid.cs1.cloudspc.it;
-      }
-
-      location /test-nuovo-marketplace/test-supplier { 
-        proxy_pass https://supplier-test.ecaasagid.cs1.cloudspc.it/;
-        proxy_set_header X-Forwarded-Proto https;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Scheme $scheme;
-        proxy_ssl_server_name on;
-        proxy_ssl_name marketplace.ecaasagid.cs1.cloudspc.it;
-        proxy_connect_timeout 10s;
-        proxy_read_timeout 20s;
-      }
-
-      location /test-nuovo-marketplace/admin { 
-        proxy_pass https://admin-test.ecaasagid.cs1.cloudspc.it/;
-        proxy_set_header X-Forwarded-Proto https;
-        proxy_ssl_name marketplace.ecaasagid.cs1.cloudspc.it;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Scheme $scheme;
-        proxy_ssl_server_name on;
-        proxy_connect_timeout 10s;
-        proxy_read_timeout 20s;
-      }
-
-      location /marketplace/ { 
+      location /marketplace/ {
         proxy_pass https://marketplace.ecaasagid.cs1.cloudspc.it/;
         proxy_set_header X-Forwarded-Proto https;
         proxy_set_header X-Real-IP $remote_addr;
@@ -99,7 +60,7 @@ redirects_cloud_italia_it:
         proxy_ssl_name marketplace.ecaasagid.cs1.cloudspc.it;
       }
 
-      location /marketplace/supplier/ { 
+      location /marketplace/supplier/ {
         proxy_pass https://supplier.ecaasagid.cs1.cloudspc.it/;
         proxy_set_header X-Forwarded-Proto https;
         proxy_set_header X-Real-IP $remote_addr;
@@ -110,7 +71,7 @@ redirects_cloud_italia_it:
         proxy_read_timeout 20s;
       }
 
-      location /marketplace/admin/ { 
+      location /marketplace/admin/ {
         proxy_pass https://admin.ecaasagid.cs1.cloudspc.it/;
         proxy_set_header X-Forwarded-Proto https;
         proxy_ssl_name marketplace.ecaasagid.cs1.cloudspc.it;


### PR DESCRIPTION
The new cloud.italia.it site is published at https://italia.github.io/cloud.italia.it-site
from the  https://github.com/italia/cloud.italia.it-site repo.

cc @emilioSp